### PR TITLE
Revert to a newer Firebase version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "assessment-uploader",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "clone": "^2.1.2",
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "^6.2.2",
+    "firebase": "^7.14.2",
     "firebase-tools": "^7.11.0",
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",


### PR DESCRIPTION
Undoes a change which downgraded the Firebase version to work with IE11 (as it broke the application). 

IE11 is a minor priority right now. 