### PR TITLE
Add call to sign out user if they encounter an error, to clear state

### DIFF
--- a/src/components/LoadingMessage.vue
+++ b/src/components/LoadingMessage.vue
@@ -22,9 +22,18 @@
 </template>
 
 <script>
+import { auth } from '@/firebase';
 export default {
   props: {
     loadFailed: Boolean,
+  },
+  watch: { 
+    loadFailed: function(newVal) { 
+      if(newVal == true){
+        // If we fail to load, log the user out
+        auth().signOut();
+      }
+    },
   },
 };
 </script>


### PR DESCRIPTION
When a user hits the error page, this is generally because of an inconsistency between the URL and the authentication email they are using. 

In some cases it can be a mangled URL. 

At the moment we just tell the user to refresh the error page, which does nothing. This PR causes them to be logged out which will throw them back to the sign in page on refresh. This should hopefully fix most user error cases of hitting this page. 