### PR TITLE
#51 - Show errors to asssesors on late IAs

### DIFF
--- a/src/components/Warning.vue
+++ b/src/components/Warning.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="govuk-warning-text">
+    <span
+      class="govuk-warning-text__icon"
+      aria-hidden="true"
+    >!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      {{ message }}
+    </strong>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    message: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -1,0 +1,73 @@
+const isDate = (date) => date instanceof Date;
+
+const isDateInFuture = (date) => {
+  // @TODO #388 update to full datetime instead of hardcoding time
+  if (!(date instanceof Date)) {
+    throw 'Supplied date must be a Date object';
+  }
+
+  const today = new Date();
+
+  date = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    13,
+    0,
+    0
+  );
+
+  return date > today;
+};
+
+const formatDate = (date, type) => {
+  if (!(date instanceof Date)) {
+    throw 'Supplied date must be a Date object';
+  }
+
+  if (type && type === 'time') {
+    return date.toLocaleString('en-GB', { hour: 'numeric', minute: 'numeric', hour12: true }).toLowerCase();
+  }
+
+  const month = date.toLocaleString('en-GB', { month: 'long' });
+
+  if (type && type === 'month') {
+    return `${month} ${date.getFullYear()}`;
+  }
+
+  return `${date.getDate()} ${month} ${date.getFullYear()}`;
+};
+
+const parseEstimatedDate = (value) => {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value != 'string') {
+    return;
+  }
+  const parts = value.split('-');
+
+  const [year, month, day] = [...parts, 1];
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return date;
+};
+
+const validateYear = (val) => {
+  val = parseInt(val);
+
+  if (isNaN(val) || val.toString().length !== 4) {
+    return null;
+  }
+
+  return val;
+};
+
+export {
+  isDate,
+  isDateInFuture,
+  formatDate,
+  parseEstimatedDate,
+  validateYear
+};

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -48,6 +48,12 @@
               </dt>
               <dd class="govuk-summary-list__value">
                 {{ assessment.dueDate | formatDate }}
+                <strong
+                  v-if="assessmentLate"
+                  class="govuk-tag govuk-tag--red"
+                >
+                  Overdue
+                </strong>
               </dd>
             </div>
           </dl>
@@ -133,6 +139,9 @@ export default {
     },
     assessorId() {
       return this.$store.getters['auth/currentUserId'];
+    },
+    assessmentLate(){
+      return !isDateInFuture(this.assessment.dueDate);
     },
     submissionPermitted() {
       if(!this.assessment.hardLimit){

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -96,6 +96,7 @@
 </template>
 <script>
 import { isDateInFuture } from '@/helpers/date';
+import BackLink from '@/components/BackLink';
 import Form from '@/components/Form/Form';
 import ErrorSummary from '@/components/Form/ErrorSummary';
 import DownloadLink from '@/components/DownloadLink';

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -48,16 +48,13 @@
               </dt>
               <dd class="govuk-summary-list__value">
                 {{ assessment.dueDate | formatDate }}
-                <strong
-                  v-if="assessmentLate"
-                  class="govuk-tag govuk-tag--red"
-                >
-                  Overdue
-                </strong>
               </dd>
             </div>
           </dl>
-
+          <Warning 
+            v-if="assessmentLate && submissionPermitted"
+            :message="`This Independent Assessment is past the due date. The Selection Exercise Team can be contacted via ` + assessment.exercise.exerciseMailbox + ` or ` + assessment.exercise.exercisePhoneNumber + `.`"
+          />
           <div
             v-if="submissionPermitted"
           >

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -52,45 +52,50 @@
             </div>
           </dl>
 
-          <p class="govuk-body-l">
-            Download the template on this page to complete your assessment.
-          </p>
+          <div
+            v-if="submissionPermitted"
+          >
+            <p class="govuk-body-l">
+              Download the template on this page to complete your assessment.
+            </p>
 
-          <p class="govuk-body-l">
-            Come back to this page to upload your finished assessment.
-          </p>
+            <p class="govuk-body-l">
+              Come back to this page to upload your finished assessment.
+            </p>
 
-          <div class="govuk-form-group">
-            <h2 class="govuk-heading-m">
-              Download self assessment template
-            </h2>
+            <div class="govuk-form-group">
+              <h2 class="govuk-heading-m">
+                Download self assessment template
+              </h2>
 
-            <DownloadLink
-              :file-name="assessment.exercise.template.file"
-              :exercise-id="assessment.exercise.id"
-              :title="assessment.exercise.template.title"
+              <DownloadLink
+                :file-name="assessment.exercise.template.file"
+                :exercise-id="assessment.exercise.id"
+                :title="assessment.exercise.template.title"
+              />
+            </div>
+
+            <FileUpload
+              id="independent-assessment-file"
+              ref="independent-assessment-file"
+              v-model="assessment.fileRef"
+              :name="fileName"
+              :path="uploadPath"
+              label="Please upload your assessment here"
+              required
             />
+
+            <button class="govuk-button">
+              Save and continue
+            </button>
           </div>
-
-          <FileUpload
-            id="independent-assessment-file"
-            ref="independent-assessment-file"
-            v-model="assessment.fileRef"
-            :name="fileName"
-            :path="uploadPath"
-            label="Please upload your assessment here"
-            required
-          />
-
-          <button class="govuk-button">
-            Save and continue
-          </button>
         </div>
       </div>
     </form>
   </div>
 </template>
 <script>
+import { isDateInFuture } from '@/helpers/date';
 import Form from '@/components/Form/Form';
 import ErrorSummary from '@/components/Form/ErrorSummary';
 import DownloadLink from '@/components/DownloadLink';
@@ -122,6 +127,17 @@ export default {
     },
     assessorId() {
       return this.$store.getters['auth/currentUserId'];
+    },
+    submissionPermitted() {
+      if(!this.assessment.hardLimit){
+        return true;
+      }
+
+      if(isDateInFuture(this.assessment.hardLimit)){
+        return true;
+      }
+
+      return false;
     },
     uploadPath() {
       const exerciseId = this.assessment.exercise.id;

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -89,6 +89,10 @@
               Save and continue
             </button>
           </div>
+          <Warning 
+            v-else
+            :message="`This Independent Assessment has expired. The Selection Exercise Team can be contacted via ` + assessment.exercise.exerciseMailbox + ` or ` + assessment.exercise.exercisePhoneNumber + `.`"
+          />
         </div>
       </div>
     </form>
@@ -96,17 +100,18 @@
 </template>
 <script>
 import { isDateInFuture } from '@/helpers/date';
-import BackLink from '@/components/BackLink';
 import Form from '@/components/Form/Form';
 import ErrorSummary from '@/components/Form/ErrorSummary';
 import DownloadLink from '@/components/DownloadLink';
 import FileUpload from '@/components/Form/FileUpload';
+import Warning from '@/components/Warning';
 
 export default {
   components: {
     ErrorSummary,
     DownloadLink,
     FileUpload,
+    Warning,
   },
   extends: Form,
   data() {

--- a/src/views/Assessments.vue
+++ b/src/views/Assessments.vue
@@ -69,23 +69,37 @@
               <td class="govuk-table__cell">
                 {{ assessment.dueDate | formatDate }}
               </td>
-              <td class="govuk-table__cell">
+              <td 
+                v-if="!assessmentLate(assessment)"
+                class="govuk-table__cell"
+              >
                 {{ assessment.status | lookup }}
+              </td>
+              <td 
+                v-if="assessmentLate(assessment)"
+                class="govuk-table__cell"
+              >
+                <strong
+                  class="govuk-tag govuk-tag--red"
+                >
+                  Overdue
+                </strong>
               </td>
               <td class="govuk-table__cell">
                 <router-link
-                  v-if="canEdit(assessment)"
+                  v-if="canEdit(assessment) && submissionPermitted(assessment)"
                   class="govuk-button govuk-button--primary"
                   :to="{ name: 'assessment-edit', params: { id: assessment.id }}"
                 >
                   View Incomplete Assessment
                 </router-link>
                 <router-link
-                  v-else-if="!canEdit(assessment) && submissionPermitted(assessment)"
+                  v-else-if="canEdit(assessment) && !submissionPermitted(assessment)"
                   class="govuk-button govuk-button--primary"
-                  :to="{ name: 'assessment-edit', params: { id: assessment.id }}"
+                  :to="{ name: 'assessment-view', params: { id: assessment.id }}"
+                  disabled
                 >
-                  View Incomplete Assessment
+                  Assessment Expired
                 </router-link>
                 <router-link
                   v-else
@@ -144,17 +158,6 @@ export default {
         },
       ];
     },
-    submissionPermitted(assessment) {
-      if(!assessment.hardLimit){
-        return true;
-      }
-
-      if(isDateInFuture(assessment.hardLimit)){
-        return true;
-      }
-
-      return false;
-    },
   },
   created() {
     // Ideally we'd use allSettled but IE doesn't support this
@@ -179,7 +182,7 @@ export default {
     },
     submissionPermitted(assessment) {
       if(!assessment.hardLimit){
-        return false;
+        return true;
       }
 
       if(isDateInFuture(assessment.hardLimit)){
@@ -187,6 +190,9 @@ export default {
       }
 
       return false;
+    },
+    assessmentLate(assessment){
+      return !isDateInFuture(assessment.dueDate) && this.canEdit(assessment);
     },
     redirectToErrorPage() {
       this.$router.replace({ name: 'assessments-not-found' });

--- a/src/views/Assessments.vue
+++ b/src/views/Assessments.vue
@@ -81,7 +81,7 @@
                   View Incomplete Assessment
                 </router-link>
                 <router-link
-                  v-else-if="canEdit(assessment) && !submissionPermitted(assessment)"
+                  v-else-if="!canEdit(assessment) && submissionPermitted(assessment)"
                   class="govuk-button govuk-button--primary"
                   :to="{ name: 'assessment-edit', params: { id: assessment.id }}"
                 >
@@ -143,6 +143,17 @@ export default {
           title: 'Complete',
         },
       ];
+    },
+    submissionPermitted(assessment) {
+      if(!assessment.hardLimit){
+        return true;
+      }
+
+      if(isDateInFuture(assessment.hardLimit)){
+        return true;
+      }
+
+      return false;
     },
   },
   created() {

--- a/src/views/Assessments.vue
+++ b/src/views/Assessments.vue
@@ -81,6 +81,13 @@
                   View Incomplete Assessment
                 </router-link>
                 <router-link
+                  v-else-if="canEdit(assessment) && !submissionPermitted(assessment)"
+                  class="govuk-button govuk-button--primary"
+                  :to="{ name: 'assessment-edit', params: { id: assessment.id }}"
+                >
+                  View Incomplete Assessment
+                </router-link>
+                <router-link
                   v-else
                   class="govuk-button govuk-button--secondary"
                   :to="{ name: 'assessment-view', params: { id: assessment.id }}"
@@ -104,6 +111,7 @@
 </template>
 <script>
 import { mapState } from 'vuex';
+import { isDateInFuture } from '@/helpers/date';
 import TabsList from '@/components/Page/TabsList';
 import LoadingMessage from '@/components/LoadingMessage';
 export default {
@@ -157,6 +165,17 @@ export default {
   methods: {
     canEdit(assessment) {
       return assessment.status === 'pending';
+    },
+    submissionPermitted(assessment) {
+      if(!assessment.hardLimit){
+        return false;
+      }
+
+      if(isDateInFuture(assessment.hardLimit)){
+        return true;
+      }
+
+      return false;
     },
     redirectToErrorPage() {
       this.$router.replace({ name: 'assessments-not-found' });

--- a/src/views/Assessments.vue
+++ b/src/views/Assessments.vue
@@ -70,20 +70,9 @@
                 {{ assessment.dueDate | formatDate }}
               </td>
               <td 
-                v-if="!assessmentLate(assessment)"
                 class="govuk-table__cell"
               >
                 {{ assessment.status | lookup }}
-              </td>
-              <td 
-                v-if="assessmentLate(assessment)"
-                class="govuk-table__cell"
-              >
-                <strong
-                  class="govuk-tag govuk-tag--red"
-                >
-                  Overdue
-                </strong>
               </td>
               <td class="govuk-table__cell">
                 <router-link


### PR DESCRIPTION
This adds a number of things:
- the Warning component from `admin`
- the date helpers from `admin`
- ~On `/assessments` an "overdue" call out when the assessment is past the deadline and incomplete~
- On `/assessments` a new disabled button for when the assessment is past the hard limit (and thus expired)
- On `/edit` ~an "overdue" call out~ the Warning component when the assessment is past the deadline and incomplete 
- On `/edit` the Warning component when the assessment is past the hard limit and expired, with contact details for the teams

This currently won't do anything, as `assessment.hardLimit` isn't being copied across in the function. We may want to tweak some stuff when we see how this is all working together. 

**Overdue but within hard limit:**
![screenshot_2020-08-04-102551](https://user-images.githubusercontent.com/5859718/89277975-6be8f600-d63d-11ea-87c4-1f27a3d79b03.png)

**Overdue and past hard limit:**
![screenshot_2020-08-04-102642](https://user-images.githubusercontent.com/5859718/89278030-7a371200-d63d-11ea-8975-18544affacb9.png)
