### PR TITLE
#67/Assessors should get a clear message when 'replacing' a file

### DIFF
--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -23,12 +23,12 @@
       v-if="haveFile && !isReplacing && !file"
       class="govuk-body-m"
     >
-      Your file has been received.
+      Your file has been {{ hasReplaced ? 'replaced' : 'received' }}.
       <a
         href="javascript:void(0)"
         class="govuk-link"
         @click.prevent="replaceFile"
-      >Replace</a>
+      >{{ hasReplaced ? 'Replace again' : 'Replace' }}</a>
     </p>
     <p v-else-if="isUploading">
       Uploading...
@@ -83,6 +83,7 @@ export default {
   data() {
     return {
       file: '',
+      hasReplaced: false,
       isReplacing: false,
       isUploading: false,
       acceptableExtensions: ['docx', 'doc', 'odt', 'fodt', 'txt'],
@@ -113,6 +114,7 @@ export default {
   },
   methods: {
     replaceFile() {
+      this.hasReplaced = true;
       this.isReplacing = true;
     },
     fileSelected() {


### PR DESCRIPTION
<img width="464" alt="Screenshot 2020-10-26 at 12 42 26" src="https://user-images.githubusercontent.com/44227249/97174754-69a0be80-178a-11eb-9be1-247f13ad5595.png">
<img width="488" alt="Screenshot 2020-10-26 at 12 41 54" src="https://user-images.githubusercontent.com/44227249/97174755-6ad1eb80-178a-11eb-870b-55b0a3e5e58a.png">
