### PR TITLE
Amend login wording

### DIFF
--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -31,7 +31,7 @@
           </div>
         </div>
         <p class="govuk-body">
-          Problems signing in? Make sure you use the same email address we previously contacted you with.
+          Problems signing in? Please contact enquiries@judicialappointments.gov.uk using same email address we have contacted you with.
         </p>
       </div>
     </div>

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -31,7 +31,7 @@
           </div>
         </div>
         <p class="govuk-body">
-          Problems signing in? Please contact enquiries@judicialappointments.gov.uk using same email address we have contacted you with.
+          Problems signing in? Please contact enquiries@judicialappointments.gov.uk using the same email address we have contacted you with.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## What's included?
 # this wording still needs to be approved, this PR is a template of the desired changes.

Assessments login page referenced "using the same email address". 
As signed URLs are the method of access it was suggested this should be changed for fear of confusion. 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Observe wording change in files tab ^^
Or below

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Old > _"Problems signing in? Make sure you use the same email address we previously contacted you with."_
New > _"Problems signing in? **Please contact enquiries@judicialappointments.gov.uk using** the same email address we have contacted you with."_

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
