### PR TITLE
#165 Change of wording for IAs

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -2,13 +2,13 @@ const formatDate = (value, type) => {
   if (value) {
     const objDate = new Date(Date.parse(value));
     switch (type) {
-    case 'month':
-      return `${objDate.toLocaleString('en-GB', { month: 'long' })} ${objDate.getUTCFullYear()}`;
-    case 'datetime':
-      return objDate.toLocaleString('en-GB');
-    case 'datetime-long': // e.g. 1 PM on 1 October 2022
-      return `${objDate.toLocaleString('en-US', { hour: 'numeric', hour12: true })} on ${objDate.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })}`;
-    default:
+      case 'month':
+        return `${objDate.toLocaleString('en-GB', { month: 'long' })} ${objDate.getUTCFullYear()}`;
+      case 'datetime':
+        return objDate.toLocaleString('en-GB');
+      case 'date-hour': // e.g. 1 pm on 1 October 2022
+        return `${objDate.toLocaleString('en-GB', { hour: 'numeric', hour12: true })} on ${objDate.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })}`;
+      default:
         return objDate.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' });
     }
   }

--- a/src/filters.js
+++ b/src/filters.js
@@ -6,6 +6,8 @@ const formatDate = (value, type) => {
       return `${objDate.toLocaleString('en-GB', { month: 'long' })} ${objDate.getUTCFullYear()}`;
     case 'datetime':
       return objDate.toLocaleString('en-GB');
+    case 'datetime-long': // e.g. 1 PM on 1 October 2022
+      return `${objDate.toLocaleString('en-US', { hour: 'numeric', hour12: true })} on ${objDate.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })}`;
     default:
         return objDate.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' });
     }

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -47,7 +47,7 @@
                 Due date
               </dt>
               <dd class="govuk-summary-list__value">
-                {{ assessment.dueDate | formatDate('datetime-long') }}
+                {{ assessment.dueDate | formatDate('date-hour') }}
               </dd>
             </div>
             <div

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -47,18 +47,7 @@
                 Due date
               </dt>
               <dd class="govuk-summary-list__value">
-                {{ assessment.dueDate | formatDate('datetime') }}
-              </dd>
-            </div>
-            <div
-              v-if="assessment.hardLimitDate && pastDueDate"
-              class="govuk-summary-list__row"
-            >
-              <dt class="govuk-summary-list__key">
-                <b> Cut off date </b>
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ assessment.hardLimitDate | formatDate('datetime') }}
+                1pm on {{ assessment.dueDate | formatDate }}
               </dd>
             </div>
             <div

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -47,7 +47,7 @@
                 Due date
               </dt>
               <dd class="govuk-summary-list__value">
-                1pm on {{ assessment.dueDate | formatDate }}
+                {{ assessment.dueDate | formatDate('datetime-long') }}
               </dd>
             </div>
             <div

--- a/src/views/Assessment/View.vue
+++ b/src/views/Assessment/View.vue
@@ -44,7 +44,7 @@
               Due date
             </dt>
             <dd class="govuk-summary-list__value">
-              1pm on {{ assessment.dueDate | formatDate }}
+              {{ assessment.dueDate | formatDate('datetime-long') }}
             </dd>
           </div>
           <div 

--- a/src/views/Assessment/View.vue
+++ b/src/views/Assessment/View.vue
@@ -44,7 +44,7 @@
               Due date
             </dt>
             <dd class="govuk-summary-list__value">
-              {{ assessment.dueDate | formatDate('datetime-long') }}
+              {{ assessment.dueDate | formatDate('date-hour') }}
             </dd>
           </div>
           <div 

--- a/src/views/Assessment/View.vue
+++ b/src/views/Assessment/View.vue
@@ -44,7 +44,7 @@
               Due date
             </dt>
             <dd class="govuk-summary-list__value">
-              {{ assessment.dueDate | formatDate('datetime') }}
+              1pm on {{ assessment.dueDate | formatDate }}
             </dd>
           </div>
           <div 

--- a/src/views/Assessments.vue
+++ b/src/views/Assessments.vue
@@ -70,7 +70,7 @@
                 {{ assessment.candidate.fullName }}
               </td>
               <td class="govuk-table__cell">
-                {{ assessment.dueDate | formatDate('datetime') }}
+                1pm on {{ assessment.dueDate | formatDate }}
               </td>
               <td 
                 class="govuk-table__cell"

--- a/src/views/Assessments.vue
+++ b/src/views/Assessments.vue
@@ -70,7 +70,7 @@
                 {{ assessment.candidate.fullName }}
               </td>
               <td class="govuk-table__cell">
-                1pm on {{ assessment.dueDate | formatDate }}
+                {{ assessment.dueDate | formatDate('datetime-long') }}
               </td>
               <td 
                 class="govuk-table__cell"

--- a/src/views/Assessments.vue
+++ b/src/views/Assessments.vue
@@ -70,7 +70,7 @@
                 {{ assessment.candidate.fullName }}
               </td>
               <td class="govuk-table__cell">
-                {{ assessment.dueDate | formatDate('datetime-long') }}
+                {{ assessment.dueDate | formatDate('date-hour') }}
               </td>
               <td 
                 class="govuk-table__cell"


### PR DESCRIPTION
## What's included?
On the Page IAs see when an assessor logs in to complete assessments the following needs to change:

- [x] Due date needs to say - "Due Date 1pm on DDMMYY
- [x] Cut off date needs to be removed

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

1. Go to independent assessments on admin site and find an assessment.
2. Copy `Test the assessments app` link address and replace `https://assessments-develop.judicialappointments.digital` with `https://jac-assessments-develop--pr153-feature-decline-asse-bot8uezq.web.app`. 

    E.g. `https://assessments-develop.judicialappointments.digital/sign-in?email=warren3@precise-minds.co.uk&ref=assessments/testData-123-2` will become `https://jac-assessments-develop--pr153-feature-decline-asse-bot8uezq.web.app
/sign-in?email=warren3@precise-minds.co.uk&ref=assessments/testData-123-2`.

3. Open the new link in the browser and it redirects to assessment site.
4. Check `Due date` format (e.g. `1 pm on 25 October 2020`).
5. Check if `Cut off date` is removed.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Screenshots:

<img width="693" alt="assessment #165 Change of wording for IAs_1" src="https://user-images.githubusercontent.com/79906532/197198659-7c08cdf5-2295-4081-a528-8d4da9f0fbf8.png">

<img width="1020" alt="assessment #165 Change of wording for IAs_2" src="https://user-images.githubusercontent.com/79906532/197198680-f5bc8ce1-9daf-4d28-ad63-acd18f1a7358.png">

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
