### PR TITLE
#129 Bugfix: duplicate call to save assessment

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -25,13 +25,13 @@ if (process.env.VUE_APP_USE_FUNCTIONS_EMULATOR === 'true') {
 const firestore = firebase.firestore();
 
 // App check
-const appCheck = firebase.appCheck();
+let appCheck;
 if (process.env.VUE_APP_RECAPTCHA_TOKEN) {
-  appCheck.activate(process.env.VUE_APP_RECAPTCHA_TOKEN);
+  appCheck = firebase.appCheck().activate(process.env.VUE_APP_RECAPTCHA_TOKEN);
 }
 
 // Other firebase exports
 const auth = firebase.auth;
 
-export { firestore, auth, functions };
+export { firestore, auth, functions, appCheck };
 export default firebase;

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -232,7 +232,6 @@ export default {
         } else {
           this.assessment.status = 'completed';
           this.assessment.filePath = `${this.buildFileFolder  }/${  this.assessment.fileRef}`;
-          await this.$store.dispatch('assessment/save', this.assessment);
           routerName = 'assessment-success';
         }
         await this.$store.dispatch('assessment/save', this.assessment);


### PR DESCRIPTION
## What's included?
Closes #169 

Plus fixes the loading of appCheck

## Who should test?
✅ Developers

## How to test?
Via Admin copy one of the links to test an IA, then amend that link to run it on this Preview URL.
Upload an IA file and press Save

**Before this fix**
There is some indication that the save has happened however the user remains on the Upload screen and there is an error with regards the date the file was uploaded:
<img width="685" alt="image" src="https://user-images.githubusercontent.com/8524401/206702125-4c91d14c-7865-42a6-bb6e-bc52d7a199f7.png">
Behind the scenes a permission denied error is sent to sentry

**After this fix**
User is navigated to the Assessment Complete success page
<img width="665" alt="image" src="https://user-images.githubusercontent.com/8524401/206701568-c047c6d0-1fe6-4fa3-9970-5f5b72394267.png">
No errors are sent to sentry

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
