### PR TITLE
feature/admin 2333 Prevent pdfs from Being Uploaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assessment-uploader",
       "version": "0.23.0",
       "dependencies": {
-        "@jac-uk/jac-kit": "4.0.0",
+        "@jac-uk/jac-kit": "4.0.7",
         "@sentry/vue": "^7.13.0",
         "@vitejs/plugin-vue": "^4.4.0",
         "firebase": "^10.7.2",
@@ -1461,9 +1461,9 @@
       "dev": true
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "4.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.0.0/839787262580e14f5568fac2665fa94ed42986f0",
-      "integrity": "sha512-2+7xVuVySLER0kTS52ooH7LK1+f5xenHTASW8DZ4gThRVgTw+x8ktvisTl+8Pw83go9v0xRUd/xtsND3WyifYA==",
+      "version": "4.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.0.7/9a73182d446f1f98390b7ee7e628bc58b22d051b",
+      "integrity": "sha512-hOcsqzxdoPidM/B5jT6r+zI6hs+sT5bKuNQXF9xbDGU14b13U4xXR1EeDZU+AdOzDj6GbYlpjOqTDIa4kf2vDQ==",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",
@@ -6999,9 +6999,9 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "4.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.0.0/839787262580e14f5568fac2665fa94ed42986f0",
-      "integrity": "sha512-2+7xVuVySLER0kTS52ooH7LK1+f5xenHTASW8DZ4gThRVgTw+x8ktvisTl+8Pw83go9v0xRUd/xtsND3WyifYA==",
+      "version": "4.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.0.7/9a73182d446f1f98390b7ee7e628bc58b22d051b",
+      "integrity": "sha512-hOcsqzxdoPidM/B5jT6r+zI6hs+sT5bKuNQXF9xbDGU14b13U4xXR1EeDZU+AdOzDj6GbYlpjOqTDIa4kf2vDQ==",
       "requires": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint-ci": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --no-fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "4.0.0",
+    "@jac-uk/jac-kit": "4.0.7",
     "@sentry/vue": "^7.13.0",
     "@vitejs/plugin-vue": "^4.4.0",
     "firebase": "^10.7.2",

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -97,8 +97,8 @@
               :path="buildFileFolder"
               :file-path="assessment.filePath"
               label="Please upload your assessment here"
-              types=".docx,.doc,.odt,.txt,.fodt"
-              hint="You can upload a .docx, .doc, .odt, .txt or .fodt file"
+              types=".docx,.doc"
+              hint="You can upload a .doc or .docx file"
               :required="!isDeclined"
             />
 

--- a/src/views/Assessment/Edit.vue
+++ b/src/views/Assessment/Edit.vue
@@ -97,6 +97,8 @@
               :path="buildFileFolder"
               :file-path="assessment.filePath"
               label="Please upload your assessment here"
+              types=".docx,.doc,.odt,.txt,.fodt"
+              hint="You can upload a .docx, .doc, .odt, .txt or .fodt file"
               :required="!isDeclined"
             />
 


### PR DESCRIPTION
## What's included?

Ticket: [Address field duplication, pdf and rogue text issues with Panel packs#2333](https://github.com/jac-uk/admin/issues/2333)

- Prevent pdfs from being uploaded.
- Update guidance to Assessors that only Word documents are acceptable.

![image](https://github.com/jac-uk/assessments/assets/79906532/f3f2cac3-ce7a-480a-b03b-2691c5580fa6)


## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Example assessments: 
- https://jac-assessments-develop--pr181-feature-admin-2333-p-2kpk9z4d.web.app/sign-in?email=test1@test.com&ref=assessments/Tb2DQgdVddCgwJXm09gr-1
- https://jac-assessments-develop--pr181-feature-admin-2333-p-2kpk9z4d.web.app/sign-in?email=test2@test.com&ref=assessments/Tb2DQgdVddCgwJXm09gr-2
- https://jac-assessments-develop--pr181-feature-admin-2333-p-2kpk9z4d.web.app/sign-in?email=test1@test.com&ref=assessments/iuKuvtiB9sOKfD7ODE2J-1
- https://jac-assessments-develop--pr181-feature-admin-2333-p-2kpk9z4d.web.app/sign-in?email=test2@test.com&ref=assessments/iuKuvtiB9sOKfD7ODE2J-2

1. Go to the assessment and upload your assessment file.
2. Check if only Word documents are acceptable to upload.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
