### PR TITLE
Bugfix/TS 426 Declined assessments not display

### DIFF
--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -79,6 +79,10 @@ export default {
         const ref = window.localStorage.getItem('signInDestination');
         if (email && ref) {
           const result = await signInWithEmailLink(auth, email, window.location.href);
+          // email from signInWithEmailLink will be converted to lowercase which might cause query issues
+          if (result.user.email !== email) {
+            result.user.email = email;
+          }
           window.localStorage.removeItem('emailForSignIn');
           window.localStorage.removeItem('signInDestination');
           await this.$store.dispatch('auth/setCurrentUser', result.user);

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -65,7 +65,7 @@ export default {
       const response = await httpsCallable(functions, 'generateSignInWithEmailLink')({ ref: ref, email: email, returnUrl: returnUrl });
       if (response && response.data && response.data.result) {
         window.localStorage.setItem('emailForSignIn', email);
-        window.localStorage.setItem('signInDestination', `${ref  }/upload`);
+        window.localStorage.setItem('signInDestination', `${ref}/upload`);
         return window.location.replace(response.data.result);
       } else {
         // console.log('mal-formed request');
@@ -80,7 +80,7 @@ export default {
         if (email && ref) {
           const result = await signInWithEmailLink(auth, email, window.location.href);
           // email in user object from signInWithEmailLink will be converted to lowercase which might cause query issue
-          if (result.user.email !== email) {
+          if (result && result.user && result.user.email !== email) {
             result.user.email = email;
           }
           window.localStorage.removeItem('emailForSignIn');

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -79,7 +79,7 @@ export default {
         const ref = window.localStorage.getItem('signInDestination');
         if (email && ref) {
           const result = await signInWithEmailLink(auth, email, window.location.href);
-          // email from signInWithEmailLink will be converted to lowercase which might cause query issues
+          // email in user object from signInWithEmailLink will be converted to lowercase which might cause query issue
           if (result.user.email !== email) {
             result.user.email = email;
           }


### PR DESCRIPTION
## Background

The email address in the user object from the function `signInWithEmailLink` will be converted to lowercase which might cause the query issues in Firestore.

## What's included?
Issue: [User Raised Issue BR_ADMIN_PR_000226#426](https://github.com/jac-uk/ticketing-system/issues/426)

- Ensure the email is correct.
- Ensure the declined assessments are displayed correctly.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
[Example assessment](https://jac-assessments-develop--pr195-bugfix-ts-426-declin-93w6rx18.web.app/sign-in?email=Chandler30@gmail.com&ref=assessments/yPPeFnHecmlmQUWvuEal-1)

1. Log in to the assessment site and view all assessments.
2. Check if the declined assessments are displayed correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/user-attachments/assets/0c65c05e-ed34-4397-abff-45f113fb1843

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
