### PR TITLE
Feat/dp 1244 hide email of assessment link

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -6,6 +6,7 @@ import {
 import store from '@/store';
 
 import SignIn from '@/views/SignIn';
+import SignInRequest from '@/views/SignInRequest';
 
 // Edit views
 import Assessments from '@/views/Assessments';
@@ -24,6 +25,15 @@ import PageNotFound from '@/views/Errors/PageNotFound';
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
+    {
+      path: '/sign-in-request',
+      name: 'sign-in-request',
+      component: SignInRequest,
+      meta: {
+        requiresAuth: false,
+        title: 'Sign In Request',
+      },
+    },
     {
       path: '/:pathMatch(.*)*',
       redirect: '/sign-in',

--- a/src/views/SignInRequest.vue
+++ b/src/views/SignInRequest.vue
@@ -2,7 +2,7 @@
   <div>
     <LoadingMessage
       v-if="loading"
-      :load-failed="!success"
+      :load-failed="success"
     />
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -31,7 +31,10 @@
               An assessment sign-in link has been sent to your email
             </h3>
             <p class="govuk-body">
-              You should receive an email with a sign-in link shortly.<br> Click the link for starting the assessment.
+              You should receive an email with a sign-in link shortly.<br>
+              Click the link for starting the assessment.<br><br>
+              Note the the link will expire in 5 minutes. <br>
+              You can request a new link by refreshing this page.
             </p>
           </div>
         </div>

--- a/src/views/SignInRequest.vue
+++ b/src/views/SignInRequest.vue
@@ -2,7 +2,7 @@
   <div>
     <LoadingMessage
       v-if="loading"
-      :load-failed="requestFailed"
+      :load-failed="!success"
     />
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -10,9 +10,35 @@
           Assessments
         </h1>
 
+        <!-- success message -->
+        <div
+          v-if="!loading && success"
+          class="govuk-notification-banner govuk-notification-banner--success"
+          role="alert"
+          aria-labelledby="govuk-notification-banner-title"
+          data-module="govuk-notification-banner"
+        >
+          <div class="govuk-notification-banner__header">
+            <h2
+              id="govuk-notification-banner-title"
+              class="govuk-notification-banner__title"
+            >
+              Success
+            </h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <h3 class="govuk-notification-banner__heading">
+              An assessment sign-in link has been sent to your email
+            </h3>
+            <p class="govuk-body">
+              You should receive an email with a sign-in link shortly.<br> Click the link for starting the assessment.
+            </p>
+          </div>
+        </div>
+
         <!-- error message -->
         <div
-          v-if="requestFailed"
+          v-if="!loading && !success"
           aria-labelledby="error-summary-title"
           role="alert"
           tabindex="-1"
@@ -30,31 +56,6 @@
               <li>You may have the wrong link, or</li>
               <li>Your assessment is no longer required.</li>
             </ul>
-          </div>
-        </div>
-
-        <!-- success message -->
-        <div
-          class="govuk-notification-banner govuk-notification-banner--success"
-          role="alert"
-          aria-labelledby="govuk-notification-banner-title"
-          data-module="govuk-notification-banner"
-        >
-          <div class="govuk-notification-banner__header">
-            <h2
-              id="govuk-notification-banner-title"
-              class="govuk-notification-banner__title"
-            >
-              Success
-            </h2>
-          </div>
-          <div class="govuk-notification-banner__content">
-            <h3 class="govuk-notification-banner__heading">
-              A sign-in link has been sent to your email
-            </h3>
-            <p class="govuk-body">
-              Click the sign-in link in your email for starting the assessment.
-            </p>
           </div>
         </div>
 
@@ -79,17 +80,12 @@ export default {
   data() {
     return {
       loading: true,
-      requestFailed: false,
+      success: false,
       formData: {},
     };
   },
   async created() {
-
     try {
-
-      console.log('this.$route.query:');
-      console.log(this.$route.query);
-
       const identity = this.$route.query.identity;
       const ref = this.$route.query.ref;
       const assessmentId = ref.split('/').length > 1 ? ref.split('/')[1] : null;
@@ -97,23 +93,15 @@ export default {
       if (identity && assessmentId) {
         this.loading = true;
         const response = await httpsCallable(functions, 'sendAssessmentSignInLink')({ assessmentId, identity });
-        console.log('RESPONSE:');
-        console.log(response);
+        let success = false;
         if (response && response.data) {
-          console.log('response.data.result:');
-          console.log(response.data.result);
-
-        } else {
-          console.log('mal-formed request');
-          this.requestFailed = true;
+          success = response.data;
         }
+        this.success = success;
       }
     }
     catch (err) {
-      console.log('ERR:');
-      console.log(err);
-      this.requestFailed = true;
-
+      this.success = false;
     } finally {
       this.loading = false;
     }

--- a/src/views/SignInRequest.vue
+++ b/src/views/SignInRequest.vue
@@ -1,0 +1,125 @@
+<template>
+  <div>
+    <LoadingMessage
+      v-if="loading"
+      :load-failed="requestFailed"
+    />
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">
+          Assessments
+        </h1>
+
+        <!-- error message -->
+        <div
+          v-if="requestFailed"
+          aria-labelledby="error-summary-title"
+          role="alert"
+          tabindex="-1"
+          data-module="govuk-error-summary"
+          class="govuk-error-summary"
+        >
+          <h2
+            id="error-summary-title"
+            class="govuk-error-summary__title"
+          >
+            There is a problem when requesting sign-in link
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <li>You may have the wrong link, or</li>
+              <li>Your assessment is no longer required.</li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- success message -->
+        <div
+          class="govuk-notification-banner govuk-notification-banner--success"
+          role="alert"
+          aria-labelledby="govuk-notification-banner-title"
+          data-module="govuk-notification-banner"
+        >
+          <div class="govuk-notification-banner__header">
+            <h2
+              id="govuk-notification-banner-title"
+              class="govuk-notification-banner__title"
+            >
+              Success
+            </h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <h3 class="govuk-notification-banner__heading">
+              A sign-in link has been sent to your email
+            </h3>
+            <p class="govuk-body">
+              Click the sign-in link in your email for starting the assessment.
+            </p>
+          </div>
+        </div>
+
+        <!-- contact JAC -->
+        <p class="govuk-body">
+          Problems receiving a sign link from your email?<br>
+          Please contact <a href="mailto:enquiries@judicialappointments.gov.uk">enquiries@judicialappointments.gov.uk</a> using the same email address we have contacted you with.
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import LoadingMessage from '@/components/LoadingMessage.vue';
+import { httpsCallable } from '@firebase/functions';
+import { functions } from '@/firebase';
+
+export default {
+  components: {
+    LoadingMessage,
+  },
+  data() {
+    return {
+      loading: true,
+      requestFailed: false,
+      formData: {},
+    };
+  },
+  async created() {
+
+    try {
+
+      console.log('this.$route.query:');
+      console.log(this.$route.query);
+
+      const identity = this.$route.query.identity;
+      const ref = this.$route.query.ref;
+      const assessmentId = ref.split('/').length > 1 ? ref.split('/')[1] : null;
+
+      if (identity && assessmentId) {
+        this.loading = true;
+        const response = await httpsCallable(functions, 'sendAssessmentSignInLink')({ assessmentId, identity });
+        console.log('RESPONSE:');
+        console.log(response);
+        if (response && response.data) {
+          console.log('response.data.result:');
+          console.log(response.data.result);
+
+        } else {
+          console.log('mal-formed request');
+          this.requestFailed = true;
+        }
+      }
+    }
+    catch (err) {
+      console.log('ERR:');
+      console.log(err);
+      this.requestFailed = true;
+
+    } finally {
+      this.loading = false;
+    }
+  },
+  methods: {
+
+  },
+};
+</script>


### PR DESCRIPTION
## What's included?
# closes https://github.com/jac-uk/digital-platform/issues/1244`
- Add new page: `/sign-in-request` for sending email containing short live sign-in link
- Update sign page: `/sign-in`,  accept the short live sign-in link, then verify the token of the link from back-end.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Check test instructions of the Admin PR: https://github.com/jac-uk/admin/pull/2647

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
