### PR TITLE
Bugfix/Login issue when email enumeration protection is enabled

### DIFF
--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -1,5 +1,5 @@
-import { auth } from '@/firebase';
-import { fetchSignInMethodsForEmail, EmailAuthProvider } from '@firebase/auth';
+import { auth, functions } from '@/firebase';
+import { httpsCallable } from '@firebase/functions';
 
 const module = {
   namespaced: true,
@@ -23,8 +23,8 @@ const module = {
         if (state.authError) { commit('setAuthError', null); }
         let allOk = false;
         if (user.emailVerified) {
-          const signInMethods = await fetchSignInMethodsForEmail(auth, user.email);
-          if (signInMethods && signInMethods.length > 0 && signInMethods.indexOf(EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD) >= 0) {
+          const response = await httpsCallable(functions, 'fetchSignInMethodsForEmail')({ email: user.email });
+          if (response.data) {
             allOk = true;
           }
         }

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -21,20 +21,16 @@ const module = {
         commit('setCurrentUser', null);
       } else {
         if (state.authError) { commit('setAuthError', null); }
-        let allOk = false;
         if (user.emailVerified) {
           const response = await httpsCallable(functions, 'checkSignInMethodsForEmail')();
           if (response.data) {
-            allOk = true;
+            commit('setCurrentUser', {
+              uid: user.uid,
+              email: user.email,
+              emailVerified: user.emailVerified,
+              displayName: user.displayName,
+            });
           }
-        }
-        if (allOk) {
-          commit('setCurrentUser', {
-            uid: user.uid,
-            email: user.email,
-            emailVerified: user.emailVerified,
-            displayName: user.displayName,
-          });
         } else {
           auth.signOut();
           commit('setAuthError', 'This site is restricted'); // @TODO Use agreed error message

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -23,7 +23,7 @@ const module = {
         if (state.authError) { commit('setAuthError', null); }
         let allOk = false;
         if (user.emailVerified) {
-          const response = await httpsCallable(functions, 'checkSignInMethodsForEmail')({ email: user.email });
+          const response = await httpsCallable(functions, 'checkSignInMethodsForEmail')();
           if (response.data) {
             allOk = true;
           }

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -23,7 +23,7 @@ const module = {
         if (state.authError) { commit('setAuthError', null); }
         let allOk = false;
         if (user.emailVerified) {
-          const response = await httpsCallable(functions, 'fetchSignInMethodsForEmail')({ email: user.email });
+          const response = await httpsCallable(functions, 'checkSignInMethodsForEmail')({ email: user.email });
           if (response.data) {
             allOk = true;
           }


### PR DESCRIPTION
## What's included?

The `fetchSignInMethodsForEmail` is deprecated when Firebase email enumeration protection is enabled.

- Replace `fetchSignInMethodsForEmail` with a callable function `checkSignInMethodsForEmail`.

Related PR: [digital-platform: Feature/fetchSignInMethodsForEmail is deprecated #1352](https://github.com/jac-uk/digital-platform/pull/1352)

## Who should test?
✅ Product owner
✅ Developers

## How to test?
[Example IA link](https://jac-assessments-develop--pr209-bugfix-login-issue-w-4jg8p8an.web.app/sign-in?email=kowei.hung@judicialappointments.digital&ref=assessments/sMF9uOPTpJD80ESeoQcp-1)

Steps:
1. Open the IA link
2. Check if you can log in to the assessments site.

[Example exercise](https://admin-develop.judicialappointments.digital/exercise/Tmdnxpho77mgnDPZvYGd/tasks/all/independent-assessments)

Steps:
1. Send IA requests and check if you receive the IA email.
2. Find the link in the IA email and replace `https://assessments-develop.judicialappointments.digital` with `https://jac-assessments-develop--pr209-bugfix-login-issue-w-4jg8p8an.web.app`.
3. Use the modified link to log in to the assessment site and check if there is any issue.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
